### PR TITLE
cm: sepolicy: allow platform apps to crop user images

### DIFF
--- a/sepolicy/platform_app.te
+++ b/sepolicy/platform_app.te
@@ -2,3 +2,6 @@
 # This is a performance optimization that allows platform apps to bypass the FUSE layer
 allow platform_app sdcard_posix:dir create_dir_perms;
 allow platform_app sdcard_posix:file create_file_perms;
+
+# Allow Gallery3D to crop user images
+allow platform_app system_app_data_file:file rw_file_perms;


### PR DESCRIPTION
Needed for gallery3d when setting contact pics

avc: denied { write } for comm=4173796E635461736B202334
path="/data/data/com.android.settings/cache/CropEditUserPhoto.jpg" dev="mmcblk0p50" ino=65849
scontext=u:r:platform_app:s0:c512,c768 tcontext=u:object_r:system_app_data_file:s0 tclass=file
permissive=0

03-05 13:07:40.741  22060-22207/com.android.gallery3d W/System.errï¹• java.io.IOException: write
failed: EACCES (Permission denied)

Change-Id: Iaa7f75abfd41c86e1a321d5f35b950f9dc7eb930
